### PR TITLE
Fix psr4 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,36 @@
 {
-    "name": "plustime-it/laravel-easy-forms", 
-    "description": "Generate, validate and process Vueitfy forms in laravel. Build frontend and backend all from laravel.",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Kane Grills",
-            "email": "kane@plustime.com.au"
-        }
-    ],
-    "minimum-stability": "beta",
-    "autoload": {
-        "psr-4": {
-            "PlusTimeIT\\EasyForms\\App\\": "src/"
-        }
-    },
-    "require": {
-        "php": ">=7.4",
-        "nesbot/carbon": "^2.16",
-        "laravel/framework": "^7.0"
-    },
-    "require-dev": {
-        "laravel/ui": "^3.2"
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "PlusTimeIT\\EasyForms\\App\\Providers\\EasyForms"
-            ],
-            "aliases": {
-                "EasyForms": "PlusTimeIT\\EasyForms\\App"
-            }
-        }
+  "name": "plustime-it/laravel-easy-forms",
+  "description": "Generate, validate and process Vueitfy forms in laravel. Build frontend and backend all from laravel.",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Kane Grills",
+      "email": "kane@plustime.com.au"
     }
+  ],
+  "minimum-stability": "beta",
+  "autoload": {
+    "psr-4": {
+      "PlusTimeIT\\EasyForms\\App\\": "src/"
+    }
+  },
+  "require": {
+    "php": "^7.3|^8.0",
+    "nesbot/carbon": "^2.16",
+    "laravel/framework": "^7.0|^8.0"
+  },
+  "require-dev": {
+    "laravel/ui": "^3.2"
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "PlusTimeIT\\EasyForms\\App\\Providers\\EasyForms"
+      ],
+      "aliases": {
+        "EasyForms": "PlusTimeIT\\EasyForms\\App"
+      }
+    }
+  }
 }

--- a/src/Objects/Errors.php
+++ b/src/Objects/Errors.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace PlusTimeIT\EasyForms\App\Models;
+namespace PlusTimeIT\EasyForms\App\Objects;
 
 use Illuminate\Database\Eloquent\Model;
 
 use PlusTimeIT\EasyForms\App\DB\Connector;
 
-class Errors extends Model {
-
+class Errors extends Model
+{
     protected $table = Connector::ERROR_TABLE;
 
     protected $fillable = [
@@ -20,13 +20,14 @@ class Errors extends Model {
 
     protected $status_labels = [ 'inactive' , 'active' ];
     protected $type_labels = [ 'validation' , 'middleware' ];
-    
-    public function getStatusLabelAttribute(){
+
+    public function getStatusLabelAttribute()
+    {
         return $this->status_labels[ $this->status ] ?? 'Status Error';
     }
-    
-    public function getTypeLabelAttribute(){
+
+    public function getTypeLabelAttribute()
+    {
         return $this->type_labels[ $this->type ] ?? 'Type Error';
     }
-
 }


### PR DESCRIPTION
```
Class PlusTimeIT\EasyForms\App\Models\Errors located in ./vendor/plustime-it/laravel-easy-forms/src/Objects/Errors.php does not comply with psr-4 autoloading standard. Skipping.
```

Error when running `composer install`.

*Cause:* `Errors` class had `Models` namespace - changed to `Objects` namespace as per folder structure.