### PR TITLE
Fix dirs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,36 @@
 {
-    "name": "plustime-it/laravel-easy-forms", 
-    "description": "Generate, validate and process Vueitfy forms in laravel. Build frontend and backend all from laravel.",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Kane Grills",
-            "email": "kane@plustime.com.au"
-        }
-    ],
-    "minimum-stability": "beta",
-    "autoload": {
-        "psr-4": {
-            "PlusTimeIT\\EasyForms\\App\\": "src/"
-        }
-    },
-    "require": {
-        "php": ">=7.4",
-        "nesbot/carbon": "^2.16",
-        "laravel/framework": "^7.0"
-    },
-    "require-dev": {
-        "laravel/ui": "^3.2"
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "PlusTimeIT\\EasyForms\\App\\Providers\\EasyForms"
-            ],
-            "aliases": {
-                "EasyForms": "PlusTimeIT\\EasyForms\\App"
-            }
-        }
+  "name": "plustime-it/laravel-easy-forms",
+  "description": "Generate, validate and process Vueitfy forms in laravel. Build frontend and backend all from laravel.",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Kane Grills",
+      "email": "kane@plustime.com.au"
     }
+  ],
+  "minimum-stability": "beta",
+  "autoload": {
+    "psr-4": {
+      "PlusTimeIT\\EasyForms\\App\\": "src/"
+    }
+  },
+  "require": {
+    "php": "^7.3|^8.0",
+    "nesbot/carbon": "^2.16",
+    "laravel/framework": "^7.0|^8.0"
+  },
+  "require-dev": {
+    "laravel/ui": "^3.2"
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "PlusTimeIT\\EasyForms\\App\\Providers\\EasyForms"
+      ],
+      "aliases": {
+        "EasyForms": "PlusTimeIT\\EasyForms\\App"
+      }
+    }
+  }
 }

--- a/src/Core/Base.php
+++ b/src/Core/Base.php
@@ -2,45 +2,47 @@
 
 namespace PlusTimeIT\EasyForms\App\Core;
 
-use PlusTimeIT\EasyForms\App\DB\Connector;
-
-use PlusTimeIT\EasyForms\App\Core\Settings;
-
 use DB;
+
 use File;
-use Schema;
+
 use Log;
+use PlusTimeIT\EasyForms\App\Core\Settings;
+use PlusTimeIT\EasyForms\App\DB\Connector;
+use Schema;
 
 // use PlusTimeIT\EasyForms\App\Core\Base;
-class Base {
+class Base
+{
+    public $directories;
 
-        public $directories;
+    public function __construct()
+    {
+        $this->directories = self::getDirectories();
+    }
 
-        public function __construct(){
-            $this->directories = self::getDirectories();
-        }
+    public static function isVendorPublished() : bool
+    {
+        return Settings::get('vendor_published') ?? false;
+    }
 
-        public static function isVendorPublished() : bool {
-            return Settings::get( 'vendor_published' ) ?? false;
-        }
+    public static function getDirectories() : object
+    {
+        $package_directories = [];
+        $package_directories[ 'base' ]        = dirname(dirname(dirname(__FILE__)));
 
-        public static function getDirectories() : object {
-            $package_directories = [];
-            $package_directories[ 'base' ]        = dirname( dirname( dirname( __FILE__ ) ) );
-            
-            // base directories
-            $package_directories[ 'config' ]      = $package_directories[ 'base' ] . '\config';
-            $package_directories[ 'resources' ]   = $package_directories[ 'base' ] . '\resources';
-            $package_directories[ 'routes' ]      = $package_directories[ 'base' ] . '\routes';
-            $package_directories[ 'src' ]         = $package_directories[ 'base' ] . '\src';
-            $package_directories[ 'views' ]       = $package_directories[ 'base' ] . '\views';
+        // base directories
+        $package_directories[ 'config' ]      = $package_directories[ 'base' ] . '/config';
+        $package_directories[ 'resources' ]   = $package_directories[ 'base' ] . '/resources';
+        $package_directories[ 'routes' ]      = $package_directories[ 'base' ] . '/routes';
+        $package_directories[ 'src' ]         = $package_directories[ 'base' ] . '/src';
+        $package_directories[ 'views' ]       = $package_directories[ 'base' ] . '/views';
 
-            // resources directories
-            $package_directories[ 'assets' ]      = $package_directories[ 'resources' ] . '\assets';
-            $package_directories[ 'components' ]  = $package_directories[ 'assets' ] . '\components';
-            $package_directories[ 'data' ]        = $package_directories[ 'resources' ] . '\data';
+        // resources directories
+        $package_directories[ 'assets' ]      = $package_directories[ 'resources' ] . '/assets';
+        $package_directories[ 'components' ]  = $package_directories[ 'assets' ] . '/components';
+        $package_directories[ 'data' ]        = $package_directories[ 'resources' ] . '/data';
 
-            return ( object ) $package_directories;
-        }
-
+        return ( object ) $package_directories;
+    }
 }

--- a/src/Objects/Errors.php
+++ b/src/Objects/Errors.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace PlusTimeIT\EasyForms\App\Models;
+namespace PlusTimeIT\EasyForms\App\Objects;
 
 use Illuminate\Database\Eloquent\Model;
 
 use PlusTimeIT\EasyForms\App\DB\Connector;
 
-class Errors extends Model {
-
+class Errors extends Model
+{
     protected $table = Connector::ERROR_TABLE;
 
     protected $fillable = [
@@ -20,13 +20,14 @@ class Errors extends Model {
 
     protected $status_labels = [ 'inactive' , 'active' ];
     protected $type_labels = [ 'validation' , 'middleware' ];
-    
-    public function getStatusLabelAttribute(){
+
+    public function getStatusLabelAttribute()
+    {
         return $this->status_labels[ $this->status ] ?? 'Status Error';
     }
-    
-    public function getTypeLabelAttribute(){
+
+    public function getTypeLabelAttribute()
+    {
         return $this->type_labels[ $this->type ] ?? 'Type Error';
     }
-
 }


### PR DESCRIPTION
Directories listed in `Base::getDirectories()` had a `\` which was causing file not found errors.

Updates `\` to `/`.

eg
`$package_directories[ 'config' ]      = $package_directories[ 'base' ] . '\config';`
updated to;
`$package_directories[ 'config' ]      = $package_directories[ 'base' ] . '/config';`